### PR TITLE
feat(#154): Clarification-First protocol for PM agent

### DIFF
--- a/.squadron/agents/pm.md
+++ b/.squadron/agents/pm.md
@@ -81,23 +81,79 @@ When you apply a type label to an issue, the Squadron framework automatically sp
 When a new issue arrives, follow this process:
 
 1. **Read the issue** -- understand the title, body, labels, and any linked issues.
-2. **Classify** -- determine the issue type and apply the matching label:
+2. **Assess clarity** -- before classifying, apply the Clarification-First Protocol (see below). If the issue is large or ambiguous, enter the clarification phase instead of proceeding to step 3.
+3. **Classify** -- determine the issue type and apply the matching label:
    - `feature` -- new functionality requested
    - `bug` -- something is broken
    - `security` -- security vulnerability or concern
    - `documentation` -- documentation update
    - `infrastructure` -- CI/CD, tooling, deployment, config changes
-   - If you cannot confidently classify, label as `needs-clarification` and ask the author for more detail in a comment.
-3. **Set priority** -- based on severity, impact, and urgency:
+   - If you cannot confidently classify even after considering clarity, label as `needs-clarification` and ask the author for more detail in a comment.
+4. **Set priority** -- based on severity, impact, and urgency:
    - `critical` -- blocks other work or affects production
    - `high` -- important, should be addressed soon
    - `medium` -- standard priority
    - `low` -- nice to have, no urgency
-4. **Check for dependencies** -- does this issue depend on or block any other open issues? If yes, note the cross-references.
-5. **Label** -- apply the type and priority labels. This automatically triggers agent creation.
-6. **Assign** -- assign the issue to `squadron-dev[bot]` for tracking visibility.
-7. **Comment** -- post a comment explaining your triage decision: type, priority, rationale, and any dependencies noted.
-8. **Sleep** -- call `report_blocked` with a description of what you are waiting for (e.g., "Waiting for feat-dev agent to implement #N").
+5. **Check for dependencies** -- does this issue depend on or block any other open issues? If yes, note the cross-references.
+6. **Label** -- apply the type and priority labels. This automatically triggers agent creation.
+7. **Assign** -- assign the issue to `squadron-dev[bot]` for tracking visibility.
+8. **Comment** -- post a comment explaining your triage decision: type, priority, rationale, and any dependencies noted.
+9. **Sleep** -- call `report_blocked` with a description of what you are waiting for (e.g., "Waiting for feat-dev agent to implement #N").
+
+## Clarification-First Protocol
+
+**Principle: Drive clarity before commitment.** Do NOT spawn a dev agent on a large or ambiguous issue. Instead, ask structured questions first.
+
+### When to Trigger Clarification
+
+An issue requires clarification if ANY of the following are true:
+
+- The issue body is **vague or underspecified** (no clear description of what to build or fix)
+- **No acceptance criteria or Definition of Done** is present
+- The scope implies **multiple sub-tasks** (e.g., "build a full X system", "overhaul the Y module")
+- The title contains scope-expanding words: "system", "platform", "overhaul", "redesign", "epic", "rework"
+- You **cannot determine what "done" looks like** from the issue as written
+
+**When NOT to trigger clarification** (proceed directly to classification):
+
+- Small, clearly-scoped issues with obvious acceptance criteria (e.g., "Fix typo in README", "Add validation to field X")
+- Bug reports with clear reproduction steps
+- Issues that already include a Definition of Done or acceptance criteria
+- Issues created from the Epic Issue template (these are already structured)
+
+### Clarification Phase
+
+When you detect a large or ambiguous issue:
+
+1. **Label** the issue `needs-clarification` and `planning`
+2. **Post a structured clarification comment** using this template:
+
+```
+**Clarification needed before work can begin.**
+
+This issue appears to need more detail before a dev agent can execute it effectively. Please help clarify the following:
+
+1. **Goal**: What is the specific end state you want to reach?
+2. **Scope**: What is explicitly in scope? What is explicitly out of scope?
+3. **Definition of Done**: How will we know this is complete? (list specific criteria)
+4. **Constraints**: Are there technology choices, timeline requirements, or integration constraints?
+5. **Priority**: If scope must be cut, what is the single most critical outcome?
+
+Once these are clarified, I will proceed with planning and agent assignment.
+```
+
+3. **Sleep** -- call `report_blocked` with: `"Clarification round 1: waiting for author response on #N"`
+
+### Commitment Gate
+
+When the author responds to your clarification questions:
+
+1. **Assess sufficiency** -- can you now determine a clear scope, type, and what "done" looks like?
+2. **If sufficient** -- proceed to classify and label the issue (step 3 of the Decision Framework). Remove `needs-clarification`. If the issue is large enough to warrant an Epic, also apply the `epic` label.
+3. **If still insufficient** -- post a **second round** of targeted follow-up questions addressing the specific gaps. Call `report_blocked` with: `"Clarification round 2: waiting for author response on #N"`
+4. **After 2 inconclusive rounds** -- if the author's responses are still insufficient after 2 rounds, apply the `needs-human` label and post a comment: `"Escalating to maintainers — this issue needs human judgment to scope before agent work can begin."` Then call `report_blocked`.
+
+**Maximum 2 clarification rounds before escalation.** Do not loop indefinitely.
 
 ## Follow-Up Protocol
 

--- a/.squadron/config.yaml
+++ b/.squadron/config.yaml
@@ -299,6 +299,8 @@ pipelines:
         action: wake_agent
       issues.closed:
         action: wake_agent
+      issues.unlabeled:
+        action: wake_agent  # Wake PM when needs-clarification is removed
       pull_request.closed:
         action: wake_agent
     stages:
@@ -320,6 +322,8 @@ pipelines:
         action: wake_agent
       issues.closed:
         action: wake_agent
+      issues.unlabeled:
+        action: wake_agent  # Wake PM when needs-clarification is removed
       pull_request.closed:
         action: wake_agent
     stages:

--- a/docs/clarification-protocol.md
+++ b/docs/clarification-protocol.md
@@ -1,0 +1,118 @@
+# Clarification-First Protocol
+
+The Clarification-First (Clarity-Before-Commitment) Protocol ensures that the PM agent drives clarity with the issue author **before** committing dev agents to work on large or ambiguous issues.
+
+## Problem
+
+Without this protocol, the PM immediately spawns a dev agent on any classified issue — even if the requirements are vague. This leads to:
+
+- Dev agents building the wrong thing
+- Wasted compute on underspecified work
+- Issues that bounce between agents without converging
+
+## How It Works
+
+### 1. Ambiguity Detection
+
+During triage (Decision Framework step 2), the PM evaluates whether the issue is clear enough for a dev agent to execute. An issue requires clarification if **any** of the following are true:
+
+| Signal | Example |
+|--------|---------|
+| Vague or underspecified body | "Build a user dashboard" with no details |
+| No acceptance criteria or Definition of Done | Issue says what but not when it's done |
+| Scope implies multiple sub-tasks | "Overhaul the authentication system" |
+| Title contains scope-expanding words | "system", "platform", "overhaul", "redesign", "epic", "rework" |
+| Cannot determine what "done" looks like | Unclear deliverables |
+
+### Issues That Skip Clarification
+
+The protocol does **not** apply to:
+
+- Small, clearly-scoped issues with obvious acceptance criteria
+- Bug reports with clear reproduction steps
+- Issues with an explicit Definition of Done or acceptance criteria
+- Issues created from the Epic Issue template (already structured)
+
+### 2. Clarification Phase
+
+When ambiguity is detected, the PM:
+
+1. Labels the issue `needs-clarification` and `planning`
+2. Posts a structured comment with five specific questions:
+   - **Goal** — What is the specific end state?
+   - **Scope** — What is in/out of scope?
+   - **Definition of Done** — How will we know it's complete?
+   - **Constraints** — Technology, timeline, integration requirements?
+   - **Priority** — What's the most critical outcome if scope must be cut?
+3. Sleeps (calls `report_blocked`) to wait for the author's response
+
+### 3. Commitment Gate
+
+When the author responds (PM is woken by `issue_comment.created` event):
+
+1. **Assess sufficiency** — Can the PM now determine a clear scope, type, and Definition of Done?
+2. **If sufficient** — Remove `needs-clarification`, proceed to classification and labeling (which triggers dev agent spawning)
+3. **If still insufficient** — Post a second round of targeted follow-up questions addressing the specific remaining gaps
+4. **After 2 inconclusive rounds** — Escalate by applying `needs-human` label. The PM does not loop indefinitely.
+
+### Flow Diagram
+
+```
+New Issue
+    │
+    ▼
+Assess Clarity ──── Clear ──────────────→ Classify & Label (normal triage)
+    │
+    │ Ambiguous
+    ▼
+Label: needs-clarification, planning
+Post structured questions (Round 1)
+Sleep
+    │
+    ▼
+Author Responds
+    │
+    ▼
+Assess Sufficiency ── Sufficient ──────→ Remove needs-clarification
+    │                                     Classify & Label
+    │ Still unclear
+    ▼
+Post follow-up questions (Round 2)
+Sleep
+    │
+    ▼
+Author Responds
+    │
+    ▼
+Assess Sufficiency ── Sufficient ──────→ Remove needs-clarification
+    │                                     Classify & Label
+    │ Still unclear
+    ▼
+Label: needs-human
+Escalate to maintainers
+```
+
+## Configuration
+
+The PM agent wakes on these events for issues it has triaged:
+
+- `issue_comment.created` — author responds to clarification questions
+- `issues.unlabeled` — `needs-clarification` label removed (e.g., by a human)
+- `issues.closed` — issue closed while awaiting clarification
+- `pull_request.closed` — related PR activity
+
+These are configured in `.squadron/config.yaml` under the `issue-triage` and `issue-reopen-triage` pipelines.
+
+## Labels Used
+
+| Label | Purpose |
+|-------|---------|
+| `needs-clarification` | Issue is awaiting author response to clarification questions |
+| `planning` | Issue is in the planning/scoping phase (not yet ready for dev work) |
+| `needs-human` | Escalated after 2 inconclusive clarification rounds |
+
+## Relationship to Other Features
+
+- **Epic Issues (#153)**: After clarification, large issues may be promoted to Epics using the Epic Issue template and `epic` label.
+- **`pm-project` Agent (#155)**: The future pm-project agent will manage Epic lifecycle after the PM completes clarification and creates the Epic.
+- **Existing Triage**: Small, clear issues are unaffected — they flow through the normal Decision Framework without triggering clarification.


### PR DESCRIPTION
## Summary

- Updates PM agent prompt (`.squadron/agents/pm.md`) with the **Clarification-First Protocol** — a structured interrogation phase that gates large/ambiguous issues before committing dev agents
- Adds ambiguity detection heuristics (vague body, missing DoD, scope-expanding keywords, multi-sub-task scope)
- Adds structured 5-question clarification template (Goal, Scope, DoD, Constraints, Priority)
- Implements 2-round commitment gate with automatic escalation to `needs-human` after 2 inconclusive rounds
- Adds `issues.unlabeled` wake event to `issue-triage` and `issue-reopen-triage` pipelines so PM wakes when `needs-clarification` is removed
- Adds `docs/clarification-protocol.md` documenting the full protocol flow with diagram

## Closes

Closes #154

## Context

Part of Epic #151 (Long-Horizon PM). The core principle: **"Drive clarity before commitment."** Previously, the PM would immediately spawn dev agents on any classified issue, even if requirements were vague. This protocol adds a gate that ensures sufficient clarity before agent work begins.

Small, clearly-scoped issues (bug reports with repro steps, single-file changes, issues with explicit acceptance criteria) are **not affected** — they bypass clarification and flow through normal triage.

## Files Changed

| File | Change |
|------|--------|
| `.squadron/agents/pm.md` | Added Clarification-First Protocol section, updated Decision Framework step 2 |
| `.squadron/config.yaml` | Added `issues.unlabeled` wake event to both triage pipelines |
| `docs/clarification-protocol.md` | New — full protocol documentation with flow diagram |

## Acceptance Criteria

- [x] Large/ambiguous issues trigger clarification questions rather than immediate dev-agent spawning
- [x] Clarification questions are structured (Goal, Scope, DoD, Constraints, Priority)
- [x] After satisfactory response, PM removes `needs-clarification` and proceeds to classification
- [x] After 2 inconclusive rounds, PM escalates to `needs-human`
- [x] Existing small/clear issues are NOT affected
- [x] Protocol is documented
- [x] All CI checks pass